### PR TITLE
refactor(dependency): Remove libtool dependency

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -4,8 +4,8 @@ steps:
   - task: NodeTool@0
     inputs:
       versionSpec: '8.9'
-  - script: npm install -g esy@0.6.2
-    displayName: 'npm install -g esy@0.6.2'
+  - script: npm install -g esy@0.6.7
+    displayName: 'npm install -g esy@0.6.7'
   - script: esy install
     displayName: 'esy install'
   - script: esy build

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,3 @@
-ifeq ($(shell uname),Darwin)
-  LIBTOOL ?= glibtool
-else
-  LIBTOOL ?= libtool
-endif
-
-ifneq ($(VERBOSE),1)
-  LIBTOOL +=--quiet
-endif
-
 override CFLAGS +=-Wall -Iinclude -std=c99 -Wpedantic
 
 ifeq ($(shell uname),SunOS)
@@ -25,8 +15,8 @@ endif
 
 CFILES=$(sort $(wildcard src/*.c))
 HFILES=$(sort $(wildcard include/*.h))
-OBJECTS=$(CFILES:.c=.lo)
-LIBRARY=libvterm.la
+OBJECTS=$(CFILES:.c=.o)
+LIBRARY=libvterm.a
 
 BINFILES_SRC=$(sort $(wildcard bin/*.c))
 BINFILES=$(BINFILES_SRC:.c=)
@@ -52,46 +42,46 @@ MANDIR=$(PREFIX)/share/man
 MAN3DIR=$(MANDIR)/man3
 
 all: $(LIBRARY) $(BINFILES)
-	@echo Using libtool $(LIBTOOL)
+	@echo Using cflags $(CFLAGS)
 
 $(LIBRARY): $(OBJECTS)
-	@echo LINK $@
-	@$(LIBTOOL) --mode=link --tag=CC $(CC) -rpath $(LIBDIR) -version-info $(VERSION_CURRENT):$(VERSION_REVISION):$(VERSION_AGE) -o $@ $^ $(LDFLAGS)
-
-src/%.lo: src/%.c $(HFILES_INT)
-	@echo CC $<
-	@$(LIBTOOL) --mode=compile --tag=CC $(CC) $(CFLAGS) -o $@ -c $<
+	@echo $(AR) $@
+	@$(AR) rcs $@ $^
 
 src/encoding/%.inc: src/encoding/%.tbl
 	@echo TBL $<
 	@perl -CSD tbl2inc_c.pl $< >$@
+
+src/%.o: src/%.c $(HFILES_INT) $(INCFILES)
+	@echo $(CC) $(CFLAGS) $<
+	@gcc $(CFLAGS) -c $< -o $@
 
 src/fullwidth.inc:
 	@perl find-wide-chars.pl >$@
 
 src/encoding.lo: $(INCFILES)
 
-bin/%: bin/%.c $(LIBRARY)
-	@echo CC $<
-	@$(LIBTOOL) --mode=link --tag=CC $(CC) $(CFLAGS) -o $@ $< -lvterm $(LDFLAGS)
+# bin/%: bin/%.c $(LIBRARY)
+# 	@echo CC $<
+# 	@$(LIBTOOL) --mode=link --tag=CC $(CC) $(CFLAGS) -o $@ $< -lvterm $(LDFLAGS)
 
-t/harness.lo: t/harness.c $(HFILES)
-	@echo CC $<
-	@$(LIBTOOL) --mode=compile --tag=CC $(CC) $(CFLAGS) -o $@ -c $<
+# t/harness.lo: t/harness.c $(HFILES)
+# 	@echo CC $<
+# 	@$(LIBTOOL) --mode=compile --tag=CC $(CC) $(CFLAGS) -o $@ -c $<
 
-t/harness: t/harness.lo $(LIBRARY)
-	@echo LINK $@
-	@$(LIBTOOL) --mode=link --tag=CC $(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+# t/harness: t/harness.lo $(LIBRARY)
+# 	@echo LINK $@
+# 	@$(LIBTOOL) --mode=link --tag=CC $(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 .PHONY: test
 test: $(LIBRARY) t/harness
 	for T in `ls t/[0-9]*.test`; do echo "** $$T **"; perl t/run-test.pl $$T $(if $(VALGRIND),--valgrind) || exit 1; done
 
-.PHONY: clean
-clean:
-	$(LIBTOOL) --mode=clean rm -f $(OBJECTS) $(INCFILES)
-	$(LIBTOOL) --mode=clean rm -f t/harness.lo t/harness
-	$(LIBTOOL) --mode=clean rm -f $(LIBRARY) $(BINFILES)
+# .PHONY: clean
+# clean:
+# 	$(LIBTOOL) --mode=clean rm -f $(OBJECTS) $(INCFILES)
+# 	$(LIBTOOL) --mode=clean rm -f t/harness.lo t/harness
+# 	$(LIBTOOL) --mode=clean rm -f $(LIBRARY) $(BINFILES)
 
 .PHONY: install
 install: install-inc install-lib 
@@ -104,12 +94,11 @@ install-inc:
 
 install-lib: $(LIBRARY)
 	install -d $(DESTDIR)$(LIBDIR)
-	$(LIBTOOL) --mode=install install $(LIBRARY) $(DESTDIR)$(LIBDIR)/$(LIBRARY)
-	$(LIBTOOL) --mode=finish $(DESTDIR)$(LIBDIR)
+	cp $(LIBRARY) $(DESTDIR)$(LIBDIR)/$(LIBRARY)
 
-install-bin: $(BINFILES)
-	install -d $(DESTDIR)$(BINDIR)
-	$(LIBTOOL) --mode=install install $(BINFILES) $(DESTDIR)$(BINDIR)/
+# install-bin: $(BINFILES)
+# 	install -d $(DESTDIR)$(BINDIR)
+# 	$(LIBTOOL) --mode=install install $(BINFILES) $(DESTDIR)$(BINDIR)/
 
 # DIST CUT
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ src/encoding/%.inc: src/encoding/%.tbl
 
 src/%.o: src/%.c $(HFILES_INT) $(INCFILES)
 	@echo $(CC) $(CFLAGS) $<
-	@gcc $(CFLAGS) -c $< -o $@
+	@$(CC) $(CFLAGS) -c $< -o $@
 
 src/fullwidth.inc:
 	@perl find-wide-chars.pl >$@

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,9 +3,9 @@
 name: $(Build.SourceVersion)
 jobs:
 - job: Linux
-  displayName: "Linux - Ubuntu 16.04"
+  displayName: "Linux - Ubuntu 18.04"
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'Ubuntu 18.04'
   steps:
   - template: .ci/esy-build-steps.yml
 

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,91 +1,7 @@
 {
-  "checksum": "75bbe39e01cbb0cd49513316b56329c1",
+  "checksum": "0cc961f41dbf4ff5ab5654751a4ba36e",
   "root": "@revery/esy-libvterm@link-dev:./package.json",
   "node": {
-    "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9": {
-      "id":
-        "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9",
-      "name": "texinfo",
-      "version":
-        "github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
-      "devDependencies": []
-    },
-    "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9": {
-      "id": "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9",
-      "name": "esy-libtools",
-      "version": "github:revery-ui/esy-libtools#c9eb685",
-      "source": {
-        "type": "install",
-        "source": [ "github:revery-ui/esy-libtools#c9eb685" ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "texinfo@github:esy-packages/esy-texinfo#4a05feafbbcc4c57d5d25899fbdab98961b9a69c@d41d8cd9",
-        "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9",
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
-    "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9": {
-      "id":
-        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9",
-      "name": "esy-help2man",
-      "version":
-        "github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [],
-      "devDependencies": []
-    },
-    "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9": {
-      "id":
-        "automake@github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0@d41d8cd9",
-      "name": "automake",
-      "version":
-        "github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-automake#e959059ccc1560a1565b16fb63ed7052c663fca0"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
-    "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9": {
-      "id":
-        "autoconf@github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3@d41d8cd9",
-      "name": "autoconf",
-      "version":
-        "github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3",
-      "source": {
-        "type": "install",
-        "source": [
-          "github:esy-packages/esy-autoconf#fb93edf57b0adc4b27b34a57a562395b224002d3"
-        ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "esy-help2man@github:esy-packages/esy-help2man#c8e6931d1dcf58a81bd801145a777fd3b115c443@d41d8cd9"
-      ],
-      "devDependencies": []
-    },
     "@revery/esy-libvterm@link-dev:./package.json": {
       "id": "@revery/esy-libvterm@link-dev:./package.json",
       "name": "@revery/esy-libvterm",
@@ -96,9 +12,7 @@
         "manifest": "package.json"
       },
       "overrides": [],
-      "dependencies": [
-        "esy-libtools@github:revery-ui/esy-libtools#c9eb685@d41d8cd9"
-      ],
+      "dependencies": [],
       "devDependencies": []
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
             [
                 "bash",
                 "-c",
-                "#{os == 'linux' ? 'EXTRA_CFLAGS=-fPIC' : ''} PREFIX=$cur__install #{os == 'windows' ? 'CC=x86_64-w64-mingw32-gcc' : 'CC=gcc'} #{os == 'windows' ? 'AR=x86_64-w64-mingw32-ar' : 'AR=ar'} make install"
+                "#{os == 'linux' ? 'CFLAGS=-fPIC' : ''} PREFIX=$cur__install #{os == 'windows' ? 'CC=x86_64-w64-mingw32-gcc' : 'CC=gcc'} #{os == 'windows' ? 'AR=x86_64-w64-mingw32-ar' : 'AR=ar'} make install"
             ]
         ],
         "install": [],

--- a/package.json
+++ b/package.json
@@ -1,31 +1,32 @@
 {
-  "name": "@revery/esy-libvterm",
-  "version": "1.0.3",
-  "description": "Esy-enabled libvterm build",
-  "license": "MIT",
-  "esy": {
-    "build": [
-        ["bash", "-c", "#{os == 'linux' ? 'CFLAGS=-fPIC' : ''} PREFIX=$cur__install #{os == 'windows' ? 'CC=x86_64-w64-mingw32-gcc' : ''} make install"]
-    ],
-    "install": [
-    ],
-    "buildsInSource":true,
-    "exportedEnv": {
-        "LIBVTERM_INCLUDE_PATH": {
-            "val": "#{self.install / 'include'}",
-            "scope": "global"
-        },
-        "LIBVTERM_LIB_PATH": {
-            "val": "#{self.lib}",
-            "scope": "global"
-        },
-        "LD_LIBRARY_PATH": {
-            "val": "#{self.lib : $LD_LIBRARY_PATH}",
-            "scope": "global"
+    "name": "@revery/esy-libvterm",
+    "version": "1.0.3",
+    "description": "Esy-enabled libvterm build",
+    "license": "MIT",
+    "esy": {
+        "build": [
+            [
+                "bash",
+                "-c",
+                "#{os == 'linux' ? 'EXTRA_CFLAGS=-fPIC' : ''} PREFIX=$cur__install #{os == 'windows' ? 'CC=x86_64-w64-mingw32-gcc' : 'CC=gcc'} #{os == 'windows' ? 'AR=x86_64-w64-mingw32-ar' : 'AR=ar'} make install"
+            ]
+        ],
+        "install": [],
+        "buildsInSource": true,
+        "exportedEnv": {
+            "LIBVTERM_INCLUDE_PATH": {
+                "val": "#{self.install / 'include'}",
+                "scope": "global"
+            },
+            "LIBVTERM_LIB_PATH": {
+                "val": "#{self.lib}",
+                "scope": "global"
+            },
+            "LD_LIBRARY_PATH": {
+                "val": "#{self.lib : $LD_LIBRARY_PATH}",
+                "scope": "global"
+            }
         }
-    }
-  },
-  "dependencies": { 
-    "esy-libtools": "github:revery-ui/esy-libtools#c9eb685"
-  }
+    },
+    "dependencies": {}
 }


### PR DESCRIPTION
Unblock Windows builds, due to errors building `autoconf`, `automake`, and `texinfo` (all dependencies for `libtool`) in the Windows environment.